### PR TITLE
Fix: Failed to find source of module `Data.Container.Instances.Everything`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ FIX_WHITESPACE?=fix-whitespace
 RTS_OPTIONS=+RTS -H3G -RTS
 AGDA=$(AGDA_EXEC) $(RTS_OPTIONS)
 EVERYTHINGS?=cabal run exes --
-DATA_INSTANCE_DIRS=`find src/Data -type d -name Instances -printf "Data/%P\n"`
+DATA_INSTANCE_DIRS=`find src/Data -type d -name Instances | sed "s|src/||"`
 
 .PHONY : all
 all : build


### PR DESCRIPTION
Cannot build the library on macOS `15.0.1 (24A348)` because of `-printf` in `GNUMakefile`:

```Makefile
DATA_INSTANCE_DIRS=`find src/Data -type d -name Instances -printf "Data/%P\n"`
```

Output of `make`:

```
/Library/Developer/CommandLineTools/usr/bin/make AGDA_EXEC=agda gen-everythings check
cabal run exes -- gen-public `find src/Data -type d -name Instances -printf "Data/%P\n"`
find: -printf: unknown primary or operator
Resolving dependencies...
Build profile: -w ghc-9.10.1 -O1
In order, the following will be built (use -v for more details):
 - cubical-utils-1.0 (exe:Everythings) (first run)
Configuring executable 'Everythings' for cubical-utils-1.0...
Preprocessing executable 'Everythings' for cubical-utils-1.0...
Building executable 'Everythings' for cubical-utils-1.0...
[1 of 1] Compiling Main             ( Everythings.hs, /Users/kei/Code/cubical-mini/dist-newstyle/build/aarch64-osx/ghc-9.10.1/cubical-utils-1.0/x/Everythings/build/Everythings/Everythings-tmp/Main.o )
[2 of 2] Linking /Users/kei/Code/cubical-mini/dist-newstyle/build/aarch64-osx/ghc-9.10.1/cubical-utils-1.0/x/Everythings/build/Everythings/Everythings
cabal run exes -- gen-except System
cabal run exes -- gen-unsafe System
agda +RTS -H3G -RTS src/README.agda
Checking README (/Users/kei/Code/cubical-mini/src/README.agda).

<redundant successful checking results omitted>

Checking Data.Container (/Users/kei/Code/cubical-mini/src/Data/Container.agda).
/Users/kei/Code/cubical-mini/src/Data/Container.agda:7,1-55
Failed to find source of module Data.Container.Instances.Everything
in any of the following locations:
  /Users/kei/Code/cubical-mini/src/Data/Container/Instances/Everything.agda
  /Users/kei/Code/cubical-mini/src/Data/Container/Instances/Everything.lagda
  /nix/store/d9rikivkzvr811m0myl0ps5h89pbjwhg-Agda-2.7.0.1-data/share/ghc-9.6.6/aarch64-osx-ghc-9.6.6/Agda-2.7.0.1/lib/prim/Data/Container/Instances/Everything.agda
  /nix/store/d9rikivkzvr811m0myl0ps5h89pbjwhg-Agda-2.7.0.1-data/share/ghc-9.6.6/aarch64-osx-ghc-9.6.6/Agda-2.7.0.1/lib/prim/Data/Container/Instances/Everything.lagda
when scope checking the declaration
  open import Data.Container.Instances.Everything public
make[1]: *** [check] Error 42
make: *** [build] Error 2
```

This PR fixes the issue by using `sed` instead of `-printf`.

Tested the changes on macOS `15.0.1 (24A348)` and NixOS `24.11 unstable` (rev `7881fbfd2e3ed1dfa315fca889b2cfd94be39337`) and think `sed` is portable enough.